### PR TITLE
Fixed imports to be consistent with existing components.

### DIFF
--- a/src/components/doge-form-email/doge-form-email.js
+++ b/src/components/doge-form-email/doge-form-email.js
@@ -1,4 +1,6 @@
-import { html } from 'lit';
+import { 
+  html
+} from "../../lib/doge-init.js"
 import { DogeForm } from '../doge-form/doge-form.js';
 
 export class DogeFormEmail extends DogeForm {

--- a/src/components/doge-form/doge-form.js
+++ b/src/components/doge-form/doge-form.js
@@ -1,4 +1,6 @@
-import { LitElement, html, css } from 'lit';
+import {
+  LitElement, css, html
+} from "../../lib/doge-init.js"
 
 export class DogeForm extends LitElement {
   static properties = {


### PR DESCRIPTION
Previous worked locally but caused `demo/:1 Uncaught TypeError: Failed to resolve module specifier "lit". Relative references must start with either "/", "./", or "../".` when running at `https://fetch.dogecoin.org/doge-form/demo/`